### PR TITLE
Pass in location of conf file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CC 	= cc
-FLAGS	= -O2 -Wall
+PORKBIND_CONF = porkbind.conf
+FLAGS	= -O2 -Wall -DPORKBIND_CONF=\"$(PORKBIND_CONF)\"
 OFLAGS 	= -c -pthread # -DDEBUG
 # You may have to add -lpthread here
 LIBS	= -pthread 

--- a/report.c
+++ b/report.c
@@ -41,9 +41,9 @@ report(struct servers *llp, const char *config)
 			vexit("fopen");
 		}
 	}
-	else if (!(cf = fopen("porkbind.conf", "r")))
+	else if (!(cf = fopen(PORKBIND_CONF, "r")))
 	{
-		fprintf(stderr,"Unable to open: porkbind.conf!\n");
+		fprintf(stderr,"Unable to open: " PORKBIND_CONF "!\n");
 
 		vexit("fopen");
 	}

--- a/usage.c
+++ b/usage.c
@@ -8,7 +8,7 @@ usage(char **argv)
 	printf("-*- PorkBind v1.3 by Derek Callaway (http://innu.org/~super) -*-\n\n");
 	printf("%s [-c file] [-s server] [-ri] domain\n", *argv);
 	printf("\tfile is configuration file to use\n");
-	printf("\t(default is porkbind.conf)\n");
+	printf("\t(default is " PORKBIND_CONF ")\n");
 	printf("\tserver is the nameserver to forward queries through\n");
 	printf("\t(default is /etc/resolv.conf nameservers)\n");
 	printf("\t-r recursively scans subdomains (i.e. sub.host.dom then host.dom)\n");


### PR DESCRIPTION
Define the name of the porkbind.conf file once, then pass it in at compile time.